### PR TITLE
Ensure that bats prints error messages by invoking sourced functions in subshell.

### DIFF
--- a/test/001_dockerhub.bats
+++ b/test/001_dockerhub.bats
@@ -3,7 +3,7 @@
 
 load ../src/cd-ci-glue
 
-DOCKER_IMAGE=madworx/cdci-dummy-test
+DOCKER_IMAGE=madworx/playground
 
 @test "DockerHub down should fail" {
     _DOCKERHUB_URL="http://localhost"
@@ -32,18 +32,17 @@ DOCKER_IMAGE=madworx/cdci-dummy-test
         [ "$status" -eq 1 ]
         run dockerhub_set_description
         [ "$status" -eq 1 ]
-        run dockerhub_push_image "${DOCKER_IMAGE}:latest"
+        run dockerhub_push_image "${DOCKER_IMAGE}:cdci-test"
         [ "$status" -eq 1 ]
     )
 }
 
 @test "DockerHub description update should work" {
-    dockerhub_set_description "${DOCKER_IMAGE}" <(echo "Last tested: $(date)")
-
+    (dockerhub_set_description "${DOCKER_IMAGE}" <(echo "cd-ci-glue last tested: $(date)"))
 }
 
 @test "DockerHub image push should work" {
-    docker build -t "${DOCKER_IMAGE}:latest" -f - . < <(echo -e 'FROM scratch\nMAINTAINER "dummy"')
-    dockerhub_push_image "${DOCKER_IMAGE}:latest"
+    docker build -q -t "${DOCKER_IMAGE}:cdci-test" -f - . < <(echo -e 'FROM scratch\nMAINTAINER "dummy"')
+    (dockerhub_push_image "${DOCKER_IMAGE}:cdci-test")
 }
 

--- a/test/002_github_pages.bats
+++ b/test/002_github_pages.bats
@@ -14,10 +14,15 @@ load ../src/cd-ci-glue
 }
 
 @test "Github incorrect github_doc_commit should fail" {
+    # No arg
     run github_doc_commit
     [ "$status" -eq 1 ]
+
+    # Non-existent directory
     run github_doc_commit /nonexistant
     [ "$status" -eq 1 ]
+
+    # Incorrect directory
     run github_doc_commit /tmp
     [ "$status" -eq 1 ]
 }
@@ -27,7 +32,7 @@ load ../src/cd-ci-glue
     # cd-ci-glue invocation; github_pages_prepare
     #
     GIT_CODIR="$(github_pages_prepare madworx/cd-ci-glue)"
-    
+
     GIT_REMOTEDIR="$(mktemp -d)"
     ( cd "${GIT_REMOTEDIR}" && git init > /dev/null )
 


### PR DESCRIPTION
Also harmonized github&dockerhub testing -> playground.